### PR TITLE
chore: add GitHub Sponsors funding.yml and sponsor badge

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: slydlake

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github)](https://github.com/sponsors/slydlake)
+
 # SlyMetrics - WordPress Prometheus and MCP metrics provider
 
 A comprehensive WordPress plugin that exports WordPress metrics in Prometheus and MCP format for monitoring including Grafana Dashboard for multi sites.


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` with `github: slydlake` to show the Sponsor button on the repo page
- Adds a GitHub Sponsors badge to `README.md`